### PR TITLE
`test_roundtrip_seekstart`

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,6 +30,9 @@ using Test
     TranscodingStreams.test_roundtrip_read(XzCompressorStream, XzDecompressorStream)
     TranscodingStreams.test_roundtrip_write(XzCompressorStream, XzDecompressorStream)
     TranscodingStreams.test_roundtrip_lines(XzCompressorStream, XzDecompressorStream)
+    if isdefined(TranscodingStreams, :test_roundtrip_seekstart)
+        TranscodingStreams.test_roundtrip_seekstart(XzCompressorStream, XzDecompressorStream)
+    end
     TranscodingStreams.test_roundtrip_transcode(XzCompressor, XzDecompressor)
 
     @test_throws ArgumentError XzCompressor(level=10)


### PR DESCRIPTION
[`test_roundtrip_seekstart`](https://github.com/JuliaIO/TranscodingStreams.jl/blob/d92fd8b9fb0b9314d82b40a96774f7f745b4dab1/ext/TestExt.jl#L65-L81) adds additional test coverage for resetting the compression session.

Ref: https://github.com/JuliaIO/TranscodingStreams.jl/issues/217